### PR TITLE
Add rule exceptions for python

### DIFF
--- a/mac/base.sb
+++ b/mac/base.sb
@@ -27,6 +27,14 @@
        (home-subpath "/Library/Caches/node-gyp")
        (home-subpath "/Library/Caches/electron")
 
+       ;; Python
+       (home-subpath "/.pyenv/shims")
+       (home-subpath "/Library/Caches/pip")
+       (regex #"/Users/[a-zA-Z]+/Library/Python/[0-9,\.]+/lib/python[0-9,\.]*/site-packages")
+       (regex #"/Users/[a-zA-Z]+/Library/Python/[0-9,\.]+/bin")
+       (regex #"/Users/[a-zA-Z]+/.pyenv/versions/[0-9,\.]+/lib/python[0-9,\.]*/site-packages")
+       (regex #"/Users/[a-zA-Z]+/.pyenv/versions/[0-9,\.]+/bin")
+
        (regex (string-append "^" (param "home") "/.histfile.*"))
        (regex "^/dev/tty.*")
        (subpath "/private/var/run/utmpx")
@@ -59,6 +67,9 @@
        (subpath "/Library/Java/JavaVirtualMachines")
        (subpath "/Library/Apple/usr/bin")
        (subpath "/Library/Apple/usr/libexec/oah") ;;rosetta
+
+       ;; Python
+       (home-subpath "/.pyenv")
 
        ;;xcoderun needs help remembering you agreed to its license terms
        (subpath "/Library/Preferences/com.apple.dt.Xcode.plist")


### PR DESCRIPTION
Hello! I recently went down the same path as you did [in your post](https://kevinlynagh.com/newsletter/2021_04_how_fast_can_plants_grow/) and came across this repo. I think it's a good balance of usability and security, particularly for downloading dependencies.

I do Python development, and pip packages (like npm packages) can also [execute arbitrary code at install time](https://github.com/DataDog/guarddog). This PR adds rules to allow you to `pip install`.

Rule explanations:

* `/.pyenv/shims`
  - [pyenv](https://github.com/pyenv/pyenv) is similar to [nvm](https://github.com/nvm-sh/nvm) by letting you have multiple python versions. When you pip install, you need write permissions to the "shims" or else you get `pyenv: cannot rehash: /Users/machaffe/.pyenv/shims isn't writable`. Some pip packages also come with executables that land in that directory as well.
* `/Library/Caches/pip`
   - cache dir for pip packages. Otherwise you get `WARNING: The directory '/Users/machaffe/Library/Caches/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled.`
* `/Users/[a-zA-Z]+/Library/Python/[0-9,\.]+/lib/python[0-9,\.]*/site-packages`
   - The site-packages dir in ~/Library is where packages are unpacked when not using pyenv.
* `/Users/[a-zA-Z]+/Library/Python/[0-9,\.]+/bin`
  - When not using pyenv, this is where package executables go, like `ansible`
* `/Users/[a-zA-Z]+/.pyenv/versions/[0-9,\.]+/lib/python[0-9,\.]*/site-packages`
  - Where packages go when using pyenv
*  `/Users/[a-zA-Z]+/.pyenv/versions/[0-9,\.]+/bin`
   - Where executables go when using pyenv

Read-only access:
* `/.pyenv`
  - Needed to execute the pyenv wrapper scripts that determine which python install to use for a given python-related command

Tested by installing/uninstalling `requests`, `pip`, `ansible`, and `Django`. More complex packages like `pytorch` will require extra custom rules, but I think this is enough for most use cases.